### PR TITLE
Syntax error

### DIFF
--- a/pf.conf
+++ b/pf.conf
@@ -24,13 +24,13 @@ set skip on lo
  
 ## Sets the interface for which PF should gather statistics such as bytes in/out and packets passed/blocked ##
 set loginterface $ext_if
+
+# Deal with attacks based on incorrect handling of packet fragments 
+scrub in all
  
 ## Set default policy ##
 block return in log all
 block out all
- 
-# Deal with attacks based on incorrect handling of packet fragments 
-scrub in all
  
 # Drop all Non-Routable Addresses 
 block drop in quick on $ext_if from $martians to any


### PR DESCRIPTION
 Traffic Normalization (e.g. scrub) https://www.freebsd.org/cgi/man.cgi?query=pf.conf&sektion=5&manpath=freebsd-release-ports
According to the pf.conf manual the Traffic Normalization rule goes before Packet Filtering. In this case scrub in the primal position generates a syntax error.